### PR TITLE
WebView package updation

### DIFF
--- a/src/InstaMojoComponent.js
+++ b/src/InstaMojoComponent.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Text, WebView } from 'react-native';
+import { Text } from 'react-native';
+import { WebView } from 'react-native-webview';
 import PropTypes from 'prop-types';
 
 export default class InstamojoPaymentComponent extends React.Component {


### PR DESCRIPTION
Hello sir, As per the actions you had given to test it, it comes out that the WEBVIEW component has been unlinked from 'react-native' package and shifted to and external package named 'react-native-webview'
So, here is the PR for updation for it